### PR TITLE
Remove "engines" restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,6 @@
   "main": "dist/stop-runaway-react-effects.cjs.js",
   "module": "dist/stop-runaway-react-effects.esm.js",
   "typings": "typings/index.d.ts",
-  "engines": {
-    "node": ">=10",
-    "npm": ">=6",
-    "yarn": ">=1"
-  },
   "scripts": {
     "build": "kcd-scripts build --bundle",
     "lint": "kcd-scripts lint",


### PR DESCRIPTION
Some tools, such as the Firebase CLI, require old node engines to be installed. Since this package only contains frontend code, the engine restriction should be unnecessary.

I haven't done a deep analysis but I can't imagine that this change would break anything. Let me know if there's something I'm missing however. 

<!--

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

<!-- Why are these changes necessary? -->

**Why**:

<!-- How were these changes implemented? -->

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
